### PR TITLE
Corrects English grammar and spelling in documentation pages

### DIFF
--- a/docs/configuration/webserver/apache/index.html
+++ b/docs/configuration/webserver/apache/index.html
@@ -90,7 +90,7 @@
 						    <section class="markdown-body">
                             <h1><a name="apache-web-server-configuration-guide" class="anchor" href="#apache-web-server-configuration-guide" rel="nofollow" aria-hidden="true"><span class="octicon octicon-link"></span></a>Apache web server configuration guide</h1>
 
-<p>The configuration files in this directory was tested with Apache version 2.4.7.</p>
+<p>The configuration files in this directory have been tested with Apache version 2.4.7.</p>
 
 <p>To set up kanban you first need to enable several additional apache modules:</p>
 
@@ -102,15 +102,15 @@
 <h2><a name="common-issues" class="anchor" href="#common-issues" rel="nofollow" aria-hidden="true"><span class="octicon octicon-link"></span></a>
 Common issues</h2>
 
-<p>Internally Kanban uses GitLab API. So misconfiguration of GitLab web server could lead to potentially kanban malfunction.
+<p>Internally Kanban uses GitLab API. So misconfiguration of the GitLab web server could lead to potential kanban malfunctions.
 Here you will find common issues we faced with GitLab + Apache setup and how to solve them.</p>
 
 <ol>
 <li><p>Boards are not showing up.</p>
 
-<p>The simptoms - you could login to kanban, you could see projects list in kanban, but could not open any board.</p>
+<p>The symptoms - you can login to kanban, you can see the projects list in kanban, but can not open any board.</p>
 
-<p>First of all check you GitLab apache config contains rewrite rules like this one:</p>
+<p>First of all check your GitLab apache config contains rewrite rules like this one:</p>
 
 <pre><code>RewriteRule .* http://127.0.0.1:8080%{REQUEST_URI} [P,QSA]
 </code></pre>
@@ -120,11 +120,11 @@ Here you will find common issues we faced with GitLab + Apache setup and how to 
 <pre><code>RewriteRule .* http://127.0.0.1:8080%{REQUEST_URI} [NE,P,QSA]
 </code></pre>
 
-<p>Also, please check the <a href="https://github.com/gitlabhq/gitlab-recipes/tree/master/web-server/apache" rel="nofollow">gitlab recipes repo</a> for latest apache configs.</p></li>
+<p>Also, please check the <a href="https://github.com/gitlabhq/gitlab-recipes/tree/master/web-server/apache" rel="nofollow">gitlab recipes repo</a> for the latest apache configs.</p></li>
 
 <li><p>Kanban reloads in a loop.</p>
 
-<p>The simptoms - you could login to kanban, but then browser keep reloading the page.</p>
+<p>The symptoms - you can login to kanban, but then the browser keep reloading the page.</p>
 
 <p>This could be caused by websockets proxy misconfiguration. Kanban listens for websocket connections on /ws/ location,
 so it should be proxied properly and there must be Host, Connection and Upgrade headers present.</p></li>
@@ -148,7 +148,7 @@ so it should be proxied properly and there must be Host, Connection and Upgrade 
 &lt;/VirtualHost&gt;
 </code></pre>
 
-<p><a href="https://github.com/leanlabsio/kanban/blob/master/docs/configuration/webserver/apache/apache.conf" rel="nofollow">view in github</a></p></li>
+<p><a href="https://github.com/leanlabsio/kanban/blob/master/docs/configuration/webserver/apache/apache.conf" rel="nofollow">view on github</a></p></li>
 </ol>
 
                             </section>

--- a/docs/configuration/webserver/nginx/index.html
+++ b/docs/configuration/webserver/nginx/index.html
@@ -90,7 +90,7 @@
 						    <section class="markdown-body">
                             <h1><a name="nginx-web-server-configuration-guide" class="anchor" href="#nginx-web-server-configuration-guide" rel="nofollow" aria-hidden="true"><span class="octicon octicon-link"></span></a>Nginx web server configuration guide</h1>
 
-<p>The configuration files in this directory was tested with nginx 1.8+.</p>
+<p>The configuration files in this directory have been tested with nginx 1.8+.</p>
 <h3><a name="config-example" class="anchor" href="#config-example" rel="nofollow" aria-hidden="true"><span class="octicon octicon-link"></span></a>
 Config example</h3>
 
@@ -113,7 +113,7 @@ Config example</h3>
 
 </code></pre>
 
-<p><a href="https://github.com/leanlabsio/kanban/blob/master/docs/configuration/webserver/nginx/nginx.conf" rel="nofollow">view in github</a></p>
+<p><a href="https://github.com/leanlabsio/kanban/blob/master/docs/configuration/webserver/nginx/nginx.conf" rel="nofollow">view on github</a></p>
 
                             </section>
                             <footer style="margin-top: 40px;" class="align-center">

--- a/docs/index.html
+++ b/docs/index.html
@@ -92,7 +92,7 @@
 
 <p>The source for LeanLabs Kanban documentation is in this directory.</p>
 
-<p>This is work in progress, feel free to <a href="https://gitlab.com/leanlabsio/kanban/issues" rel="nofollow">submit an issues</a> or contribute to help improve documentation.</p>
+<p>This is a work in progress, feel free to <a href="https://gitlab.com/leanlabsio/kanban/issues" rel="nofollow">submit issues</a> or contribute to help improve the documentation.</p>
 <h3><a name="installation" class="anchor" href="#installation" rel="nofollow" aria-hidden="true"><span class="octicon octicon-link"></span></a>
 Installation</h3>
 

--- a/docs/installation/binary.html
+++ b/docs/installation/binary.html
@@ -119,15 +119,15 @@ service redis-server start
 
 <p><img src="gitlab_oauth/applications.jpg" alt="applications page"></p>
 
-<p>After this you will see &#34;New application&#34; form, where &#34;Name&#34; is arbitrary name, e.g. &#34;kanban&#34;, and &#34;Redirect URI&#34; is an URL in kanban where users will be sent after authorization in GitLab.</p>
+<p>After this you will see the &#34;New application&#34; form, where &#34;Name&#34; is an arbitrary name, e.g. &#34;kanban&#34;, and &#34;Redirect URI&#34; is an URL in kanban where users will be sent after authorization in GitLab.</p>
 
 <p><img src="gitlab_oauth/create_desc.jpg" alt="new application"></p>
 
-<p><strong>IMPORTANT</strong> The &#34;Redirect URI&#34; is composed of 2 parts: the hostname of you kanban installation, and the fixed path part, referring to actual route to redirect.</p>
+<p><strong>IMPORTANT</strong> The &#34;Redirect URI&#34; is composed of 2 parts: the hostname of your kanban installation, and the fixed path part, referring to the actual route to redirect to.</p>
 
-<p>The path part always the same -  &#34;/assets/html/user/views/oauth.html&#34;, the hostname part strongly depends on kanban &#34;--server-hostname&#34; option, the hostname of redirect uri and option must be the same, including protocol and port information.</p>
+<p>The path part is always the same -  &#34;/assets/html/user/views/oauth.html&#34;, the hostname part strongly depends on kanban &#34;--server-hostname&#34; option, the hostname of the redirect URI and option must be the same, including protocol and port information.</p>
 
-<p><strong>IMPORTANT</strong> Redirect URL must include port if not 80 or 443.</p>
+<p><strong>IMPORTANT</strong> Redirect URL must include the port if it is not 80 or 443.</p>
 
 <p>Here are some examples of composing redirect uri:</p>
 
@@ -135,7 +135,7 @@ service redis-server start
 
 <p>--server-hostname=&#34;<a href="http://mykanban.com:9000%22" rel="nofollow">http://mykanban.com:9000&#34;</a>, then &#34;Redirect URI&#34; must be &#34;<a href="http://mykanban.com:9000/assets/html/user/views/oauth.html%22" rel="nofollow">http://mykanban.com:9000/assets/html/user/views/oauth.html&#34;</a></p>
 
-<p>For now we does not support setting up kanban in GitLab &#34;subdirectory&#34;, e.g. you can not setup kanban to be accessed via &#34;<a href="http://mygitlab.com/kanban%22" rel="nofollow">http://mygitlab.com/kanban&#34;</a>, this is planned in future releases.</p></li>
+<p>For now we do not support setting up kanban in a GitLab &#34;subdirectory&#34;, e.g. you can not setup kanban to be accessed via &#34;<a href="http://mygitlab.com/kanban%22" rel="nofollow">http://mygitlab.com/kanban&#34;</a>, this is planned in future releases.</p></li>
 
 <li><p>Start LeanLabs Kanban application</p>
 
@@ -150,7 +150,7 @@ service redis-server start
     --redis-addr=&#34;127.0.0.1:6379&#34;
 </code></pre>
 
-<p>That is it. Now you should be able to access board on &#34;<a href="http://mykanban.com%22" rel="nofollow">http://mykanban.com&#34;</a> and login via GitLab OAuth.</p></li>
+<p>That is it. Now you should be able to access the board on &#34;<a href="http://mykanban.com%22" rel="nofollow">http://mykanban.com&#34;</a> and login via GitLab OAuth.</p></li>
 </ol>
 <h2><a name="available-configuration-options" class="anchor" href="#available-configuration-options" rel="nofollow" aria-hidden="true"><span class="octicon octicon-link"></span></a>
 Available configuration options</h2>
@@ -162,37 +162,37 @@ Available configuration options</h2>
 <p>Here are the list of available command line option and mirroring env variables:</p>
 
 <ul>
-<li><p><strong>--server-listen</strong> (env <strong>KANBAN_SERVER_LISTEN</strong>) - default to &#34;0.0.0.0:80&#34;, IP:PORT (e.g. 0.0.0.0:80) which kanban will listen for incoming requests.</p></li>
+<li><p><strong>--server-listen</strong> (env <strong>KANBAN_SERVER_LISTEN</strong>) - default to &#34;0.0.0.0:80&#34;. The IP:PORT (e.g. 0.0.0.0:80) which kanban will listen for incoming requests.</p></li>
 
-<li><p><strong>--server-hostname</strong> (env <strong>KANBAN_SERVER_HOSTNAME</strong>) - default to &#34;<a href="http://localhost%22" rel="nofollow">http://localhost&#34;</a>, URL on which LeanLabs Kanban will be reachable (e.g. <a href="http://mykanban.com" rel="nofollow">http://mykanban.com</a>). The hostname must be composed of the protocol part (&#34;http://&#34; or &#34;https://&#34;), the domain or ip (e.g. mykanban.com or 192.168.0.100) and the port, if not 80 or 443 (e.g. &#34;:9000&#34;). For example, if board will be reachable on domain &#34;mykanban.com&#34; and port 9000 the resulting value must be &#34;<a href="http://mykanban.com:9000%22" rel="nofollow">http://mykanban.com:9000&#34;</a>.</p></li>
+<li><p><strong>--server-hostname</strong> (env <strong>KANBAN_SERVER_HOSTNAME</strong>) - default to &#34;<a href="http://localhost%22" rel="nofollow">http://localhost&#34;</a>. The URL on which LeanLabs Kanban will be reachable (e.g. <a href="http://mykanban.com" rel="nofollow">http://mykanban.com</a>). The hostname must be composed of the protocol part (&#34;http://&#34; or &#34;https://&#34;), the domain or IP (e.g. mykanban.com or 192.168.0.100) and the port, if not 80 or 443 (e.g. &#34;:9000&#34;). For example, if the board will be reachable on domain &#34;mykanban.com&#34; and port 9000, the resulting value must be &#34;<a href="http://mykanban.com:9000%22" rel="nofollow">http://mykanban.com:9000&#34;</a>.</p></li>
 
-<li><p><strong>--security-secret</strong> (env <strong>KANBAN_SECURITY_SECRET</strong>) - default to &#34;qwerty&#34;, this string is used to generate user auth tokens. Kanban uses json web tokens to identify users, this string is used to encrypt those tokens. You must change it to something more random then &#34;qwerty&#34; if you installation could be exposed to the whole internet.</p></li>
+<li><p><strong>--security-secret</strong> (env <strong>KANBAN_SECURITY_SECRET</strong>) - default to &#34;qwerty&#34;. This string is used to generate user auth tokens. Kanban uses JSON web tokens to identify users, this string is used to encrypt those tokens. You must change it to something more random than &#34;qwerty&#34; else your installation could be exposed to the whole internet.</p></li>
 
-<li><p><strong>--gitlab-url</strong> (env <strong>KANBAN_GITLAB_URL</strong>) - default to &#34;<a href="https://gitlab.com%22" rel="nofollow">https://gitlab.com&#34;</a>, your GitLab host URL, if you use self hosted GitLab installation the value must also include the protocol, domain or ip and the port if not 80 or 443.</p>
+<li><p><strong>--gitlab-url</strong> (env <strong>KANBAN_GITLAB_URL</strong>) - default to &#34;<a href="https://gitlab.com%22" rel="nofollow">https://gitlab.com&#34;</a>. Your GitLab host URL, if you use self hosted GitLab installation the value must also include the protocol, domain or IP and the port if it is not 80 or 443.</p>
 
-<p><strong>WARNING</strong> The kanban board should be able to resolve GitLab installation domain. If you GitLab installation domain could not be resolved, then you must explicitly define the GitLab server IP, e.g. via hosts file or dnsmasq.</p></li>
+<p><strong>WARNING</strong> The kanban board should be able to resolve the GitLab installation domain. If your GitLab installation domain could not be resolved, then you must explicitly define the GitLab server IP, e.g. via hosts file or dnsmasq.</p></li>
 
-<li><p><strong>--gitlab-client</strong> (env <strong>KANBAN_GITLAB_CLIENT</strong>) - default to &#34;qwerty&#34;, your GitLab OAuth client id</p></li>
+<li><p><strong>--gitlab-client</strong> (env <strong>KANBAN_GITLAB_CLIENT</strong>) - default to &#34;qwerty&#34;. Your GitLab OAuth client id</p></li>
 
-<li><p><strong>--gitlab-secret</strong> (env <strong>KANBAN_GITLAB_SECRET</strong>) - default to &#34;qwerty&#34;, your GitLab OAuth client secret key</p></li>
+<li><p><strong>--gitlab-secret</strong> (env <strong>KANBAN_GITLAB_SECRET</strong>) - default to &#34;qwerty&#34;. Your GitLab OAuth client secret key</p></li>
 
-<li><p><strong>--redis-addr</strong> (env <strong>KANBAN_REDIS_ADDR</strong>) - default to &#34;127.0.0.1:6379&#34;, Redis server address - IP:PORT. You have also may be used unix socket, if you set address as &#34;unix:///path/to/sock.sock&#34;. LeanLabs Kanban requires redis server to function properly, it stores users identities there.</p></li>
+<li><p><strong>--redis-addr</strong> (env <strong>KANBAN_REDIS_ADDR</strong>) - default to &#34;127.0.0.1:6379&#34;. The Redis server address - IP:PORT. You may also use a unix socket, if you set address as &#34;unix:///path/to/sock.sock&#34;. LeanLabs Kanban requires the Redis server to function properly, it stores users identities there.</p></li>
 
-<li><p><strong>--redis-password</strong> (env <strong>KANBAN_REDIS_PASSWORD</strong>) - default to &#34;&#34; (empty string), Redis server password if any.</p></li>
+<li><p><strong>--redis-password</strong> (env <strong>KANBAN_REDIS_PASSWORD</strong>) - default to &#34;&#34; (empty string). The Redis server password if any.</p></li>
 
-<li><p><strong>--redis-db</strong> (env ** KANBAN_REDIS_DB**) - default to &#34;0&#34;, redis server database numeric index, from 0 to 16, also rarely required to be changed if ever.</p></li>
+<li><p><strong>--redis-db</strong> (env ** KANBAN_REDIS_DB**) - default to &#34;0&#34;. The Redis server database numeric index, from 0 to 16, also rarely required to be changed if ever.</p></li>
 </ul>
 
-<p>You could list available options with &#34;--help&#34; subcommand:</p>
+<p>You can list available options with &#34;--help&#34; subcommand:</p>
 
 <pre><code class="bash">kanban server --help
 </code></pre>
 <h2><a name="setting-up-behind-proxy" class="anchor" href="#setting-up-behind-proxy" rel="nofollow" aria-hidden="true"><span class="octicon octicon-link"></span></a>
 Setting up behind proxy.</h2>
 
-<p>LeanLabs Kanban board processes http requests directly, but sometimes you want to set it behind proxy, e.g. if you want https you definitely should use proxy, because for now kanban does not able to handle https traffic directly.</p>
+<p>LeanLabs Kanban board processes HTTP requests directly, but sometimes you may want to set it up behind a proxy, e.g. if you want HTTPS you definitely should use  proxy, because for now kanban is not able to handle HTTPS traffic directly.</p>
 
-<p>Proxy configuration, including supported configuration files also <a href="/docs/configuration/" rel="nofollow">described in our docs</a>.</p>
+<p>Proxy configuration, including supported configuration files, is <a href="/docs/configuration/" rel="nofollow">described in our docs</a>.</p>
 
                             </section>
                             <footer style="margin-top: 40px;" class="align-center">

--- a/docs/installation/docker.html
+++ b/docs/installation/docker.html
@@ -96,7 +96,7 @@
 <h2><a name="running-the-image" class="anchor" href="#running-the-image" rel="nofollow" aria-hidden="true"><span class="octicon octicon-link"></span></a>
 Running the image</h2>
 
-<p>LeanLabs Kanban image requires Redis, which <a href="https://hub.docker.com/r/leanlabs/redis/" rel="nofollow">we are also providing</a>, it is just 6Mb is size, which is much smaller then official redis docker image.</p>
+<p>the LeanLabs Kanban image requires Redis, which <a href="https://hub.docker.com/r/leanlabs/redis/" rel="nofollow">we are also providing</a>, it is just 6Mb is size, which is much smaller than the official redis docker image.</p>
 
 <ol>
 <li><p>Start the Redis container:</p>
@@ -104,9 +104,9 @@ Running the image</h2>
 <pre><code class="bash">docker run -d -p 6379:6379 --name kanban_redis leanlabs/redis:1.0.0
 </code></pre>
 
-<p>This will start redis container with name kanban_redis, in daemon mode, mapping it 6379 port to host 6379 port.</p></li>
+<p>This will start the redis container with the name kanban_redis, in daemon mode, mapping it 6379 port to host 6379 port.</p></li>
 
-<li><p>Start kanban container:</p>
+<li><p>Start the kanban container:</p>
 
 <pre><code class="bash">docker run -d
     --link kanban_redis:kanban_redis
@@ -117,9 +117,9 @@ Running the image</h2>
     leanlabs/kanban:1.4.0
 </code></pre>
 
-<p>This will start kanban board container in daemon mode, linked to redis container.</p>
+<p>This will start the kanban board container in daemon mode, linked to the redis container.</p>
 
-<p>That is basically all you need, now you should be able to access kanban board via <a href="http://localhost" rel="nofollow">http://localhost</a>, if you want to setup OAuth access please refer to next section.</p></li>
+<p>That is basically all you need. Now you should be able to access kanban board via <a href="http://localhost" rel="nofollow">http://localhost</a>, if you would like to setup OAuth access please refer to the next section.</p></li>
 </ol>
 <h2><a name="setting-up-oauth-via-gitlab" class="anchor" href="#setting-up-oauth-via-gitlab" rel="nofollow" aria-hidden="true"><span class="octicon octicon-link"></span></a>
 Setting up OAuth via GitLab</h2>
@@ -127,41 +127,41 @@ Setting up OAuth via GitLab</h2>
 <ol>
 <li><p>Setup application for OAuth in GitLab.</p>
 
-<p>Go to your GitLab profile section &#34;Application&#34; and press button &#34;New Application&#34;</p>
+<p>Go to your GitLab profile section &#34;Application&#34; and press the &#34;New Application&#34; button</p>
 
 <p><img src="gitlab_oauth/applications.jpg" alt="applications page"></p>
 
-<p>After this you will see &#34;New application&#34; form, where &#34;Name&#34; is arbitrary name, e.g. &#34;kanban&#34;, and &#34;Redirect URI&#34; is an URL in kanban where users will be sent after authorization in GitLab.</p>
+<p>After this you will see the &#34;New application&#34; form, where &#34;Name&#34; is an arbitrary name, e.g. &#34;kanban&#34;, and &#34;Redirect URI&#34; is an URL in kanban where users will be sent after authorization in GitLab.</p>
 
 <p><img src="gitlab_oauth/create_desc.jpg" alt="new application"></p>
 
-<p><strong>IMPORTANT</strong> The &#34;Redirect URI&#34; is composed of 2 parts: the hostname of you kanban installation, and the fixed path part, referring to actual route to redirect.</p>
+<p><strong>IMPORTANT</strong> The &#34;Redirect URI&#34; is composed of 2 parts: the hostname of your kanban installation, and the fixed path part, referring to the actual route to redirect to.</p>
 
-<p>The path part always the same -  &#34;/assets/html/user/views/oauth.html&#34;, the hostname part strongly depends on kanban container &#34;KANBAN_SERVER_HOSTNAME&#34; environment variable, the hostname of redirect uri and env variable must be the same, including protocol and port information.</p>
+<p>The path part is always the same -  &#34;/assets/html/user/views/oauth.html&#34;, the hostname part strongly depends on the kanban container &#34;KANBAN_SERVER_HOSTNAME&#34; environment variable, the hostname of redirect URI and env variable must be the same, including protocol and port information.</p>
 
-<p><strong>IMPORTANT</strong> Redirect URL must include port if not 80 or 443.</p>
+<p><strong>IMPORTANT</strong> Redirect URL must include the port if it is not 80 or 443.</p>
 
-<p>Here are some examples of composing redirect uri:</p>
+<p>Here are some examples of composing the redirect URI:</p>
 
 <p>KANBAN_SERVER_HOSTNAME=<a href="http://mykanban.com" rel="nofollow">http://mykanban.com</a>, then the &#34;Redirect URI&#34; must be &#34;<a href="http://mykanban.com/assets/html/user/views/oauth.html%22" rel="nofollow">http://mykanban.com/assets/html/user/views/oauth.html&#34;</a></p>
 
 <p>KANBAN_SERVER_HOSTNAME=<a href="http://mykanban.com:9000" rel="nofollow">http://mykanban.com:9000</a>, then &#34;Redirect URI&#34; must be &#34;<a href="http://mykanban.com:9000/assets/html/user/views/oauth.html%22" rel="nofollow">http://mykanban.com:9000/assets/html/user/views/oauth.html&#34;</a></p>
 
-<p>For now we does not support setting up kanban in GitLab &#34;subdirectory&#34;, e.g. you can not setup kanban to be accessed via &#34;<a href="http://mygitlab.com/kanban%22" rel="nofollow">http://mygitlab.com/kanban&#34;</a>, this is planned in future releases.</p></li>
+<p>For now we do not support setting up kanban in a GitLab &#34;subdirectory&#34;, e.g. you can not setup kanban to be accessed via &#34;<a href="http://mygitlab.com/kanban%22" rel="nofollow">http://mygitlab.com/kanban&#34;</a>, this is planned in future releases.</p></li>
 
-<li><p>Pass OAuth client id and client secret to kanban.</p>
+<li><p>Pass OAuth client ID and client secret to kanban.</p>
 
-<p>After registering application in GitLab you should provide OAuth client ID and client secret to kanban.</p>
+<p>After registering the application in GitLab you should provide the OAuth client ID and client secret to kanban.</p>
 
 <p><img src="gitlab_oauth/create_success_alt.jpg" alt="installed application"></p>
 
 <p>They are passed to container via environment variables:</p>
 
-<p><strong>KANBAN_GITLAB_CLIENT</strong> - GitLab OAuth client id</p>
+<p><strong>KANBAN_GITLAB_CLIENT</strong> - GitLab OAuth client ID</p>
 
 <p><strong>KANBAN_GITLAB_SECRET</strong> - GitLab OAuth client secret</p>
 
-<p>Now the command to running the kanban container should be:</p>
+<p>Now the command to run the kanban container should be:</p>
 
 <pre><code class="bash">docker run -d -p
     --link kanban_redis:kanban_redis
@@ -188,32 +188,32 @@ Environment variables</h2>
 <p>Here are the list of available variables and their meaning:</p>
 
 <ul>
-<li><p><strong>KANBAN_SERVER_LISTEN</strong> - default to &#34;0.0.0.0:80&#34;, IP:PORT (e.g. 0.0.0.0:80) which kanban will listen for incoming requests, when setting up with docker you rarely if ever will need to set this variable</p></li>
+<li><p><strong>KANBAN_SERVER_LISTEN</strong> - default to &#34;0.0.0.0:80&#34;. The IP:PORT (e.g. 0.0.0.0:80) which kanban will listen for incoming requests. When setting up with docker you rarely if ever will need to set this variable</p></li>
 
-<li><p><strong>KANBAN_SERVER_HOSTNAME</strong> - default to &#34;<a href="http://localhost%22" rel="nofollow">http://localhost&#34;</a>, URL on which LeanLabs Kanban will be reachable (e.g. <a href="http://mykanban.com" rel="nofollow">http://mykanban.com</a>). The hostname must be composed of the protocol part (&#34;http://&#34; or &#34;https://&#34;), the domain or ip (e.g. mykanban.com or 192.168.0.100) and the port, if not 80 or 443 (e.g. &#34;:9000&#34;). For example, if board will be reachable on domain &#34;mykanban.com&#34; and port 9000 the resulting value must be &#34;<a href="http://mykanban.com:9000%22" rel="nofollow">http://mykanban.com:9000&#34;</a>.</p></li>
+<li><p><strong>KANBAN_SERVER_HOSTNAME</strong> - default to &#34;<a href="http://localhost%22" rel="nofollow">http://localhost&#34;</a>. The URL on which LeanLabs Kanban will be reachable (e.g. <a href="http://mykanban.com" rel="nofollow">http://mykanban.com</a>). The hostname must be composed of the protocol part (&#34;http://&#34; or &#34;https://&#34;), the domain or IP (e.g. mykanban.com or 192.168.0.100) and the port, if not 80 or 443 (e.g. &#34;:9000&#34;). For example, if the board will be reachable on domain &#34;mykanban.com&#34; and port 9000 the resulting value must be &#34;<a href="http://mykanban.com:9000%22" rel="nofollow">http://mykanban.com:9000&#34;</a>.</p></li>
 
-<li><p><strong>KANBAN_SECURITY_SECRET</strong> - default to &#34;qwerty&#34;, this string is used to generate user auth tokens. Kanban uses json web tokens to identify users, this string is used to encrypt those tokens. You must change it to something more random then &#34;qwerty&#34; if you installation could be exposed to the whole internet.</p></li>
+<li><p><strong>KANBAN_SECURITY_SECRET</strong> - default to &#34;qwerty&#34;. This string is used to generate user auth tokens. Kanban uses JSON web tokens to identify users, this string is used to encrypt those tokens. You must change it to something more random than &#34;qwerty&#34; else your installation could be exposed to the whole internet.</p></li>
 
-<li><p><strong>KANBAN_GITLAB_URL</strong> - default to &#34;<a href="https://gitlab.com%22" rel="nofollow">https://gitlab.com&#34;</a>, your GitLab host URL, if you use self hosted GitLab installation the value must also include the protocol, domain or ip and the port if not 80 or 443.</p>
+<li><p><strong>KANBAN_GITLAB_URL</strong> - default to &#34;<a href="https://gitlab.com%22" rel="nofollow">https://gitlab.com&#34;</a>, your GitLab host URL. If you use a self hosted GitLab installation the value must also include the protocol, domain or IP and the port, if not 80 or 443.</p>
 
-<p><strong>WARNING</strong> The kanban board should be able to resolve GitLab installation domain. If you GitLab installation domain could not be resolved, then you must explicitly define the GitLab server IP, you could do this by passing --add-host to docker run command, e.g. --add-host=&#34;mygitlab.com:192.168.0.200&#34;.</p></li>
+<p><strong>WARNING</strong> The kanban board should be able to resolve the GitLab installation domain. If your GitLab installation domain could not be resolved, then you must explicitly define the GitLab server IP, you could do this by passing --add-host to docker run command, e.g. --add-host=&#34;mygitlab.com:192.168.0.200&#34;.</p></li>
 
-<li><p><strong>KANBAN_GITLAB_CLIENT</strong> - default to &#34;qwerty&#34;, your GitLab OAuth client id</p></li>
+<li><p><strong>KANBAN_GITLAB_CLIENT</strong> - default to &#34;qwerty&#34;. Your GitLab OAuth client id</p></li>
 
-<li><p><strong>KANBAN_GITLAB_SECRET</strong> - default to &#34;qwerty&#34;, your GitLab OAuth client secret key</p></li>
+<li><p><strong>KANBAN_GITLAB_SECRET</strong> - default to &#34;qwerty&#34;. Your GitLab OAuth client secret key</p></li>
 
-<li><p><strong>KANBAN_REDIS_ADDR</strong> - default to &#34;127.0.0.1:6379&#34;, Redis server address - IP:PORT. You have also may be used unix socket, if you set address as &#34;unix:///path/to/sock.sock&#34;. LeanLabs Kanban requires redis server to function properly, it stores users identities there.</p></li>
+<li><p><strong>KANBAN_REDIS_ADDR</strong> - default to &#34;127.0.0.1:6379&#34;. The Redis server address - IP:PORT. You may also use a unix socket, if you set address as &#34;unix:///path/to/sock.sock&#34;. LeanLabs Kanban requires the Redis server to function properly, it stores users identities there.</p></li>
 
-<li><p><strong>KANBAN_REDIS_PASSWORD</strong> - default to &#34;&#34; (empty string), Redis server password if any.</p></li>
+<li><p><strong>KANBAN_REDIS_PASSWORD</strong> - default to &#34;&#34; (empty string). The Redis server password if any.</p></li>
 
-<li><p><strong>KANBAN_REDIS_DB</strong> - default to &#34;0&#34;, redis server database numeric index, from 0 to 16, also rarely required to be changed if ever.</p></li>
+<li><p><strong>KANBAN_REDIS_DB</strong> - default to &#34;0&#34;. The Redis server database numeric index, from 0 to 16, also rarely required to be changed if ever.</p></li>
 </ul>
 <h2><a name="setting-up-behind-proxy" class="anchor" href="#setting-up-behind-proxy" rel="nofollow" aria-hidden="true"><span class="octicon octicon-link"></span></a>
 Setting up behind proxy.</h2>
 
-<p>LeanLabs Kanban board processes http requests directly, but sometimes you want to set it behind proxy, e.g. if you want https you definitely should use proxy, because for now kanban does not able to handle https traffic directly.</p>
+<p>LeanLabs Kanban board processes HTTP requests directly, but sometimes you may want to set it up behind a proxy, e.g. if you want HTTPS you definitely should use a proxy, because for now kanban is not able to handle HTTPS traffic directly.</p>
 
-<p>Proxy configuration, including supported configuration files also <a href="/docs/configuration/" rel="nofollow">described in our docs</a>.</p>
+<p>Proxy configuration, including supported configuration files, is <a href="/docs/configuration/" rel="nofollow">described in our docs</a>.</p>
 
                             </section>
                             <footer style="margin-top: 40px;" class="align-center">

--- a/docs/installation/index.html
+++ b/docs/installation/index.html
@@ -90,7 +90,7 @@
 						    <section class="markdown-body">
                             <h1><a name="installation" class="anchor" href="#installation" rel="nofollow" aria-hidden="true"><span class="octicon octicon-link"></span></a>Installation</h1>
 
-<p>Here you will find guides for installing kanban board.</p>
+<p>Here you will find guides for installing the kanban board.</p>
 
 <p>For now we officially support two installation types:</p>
 

--- a/docs/usage/customize-columns.html
+++ b/docs/usage/customize-columns.html
@@ -90,7 +90,7 @@
 						    <section class="markdown-body">
                             <h1><a name="customizing-columns" class="anchor" href="#customizing-columns" rel="nofollow" aria-hidden="true"><span class="octicon octicon-link"></span></a>Customizing columns</h1>
 
-<p>Kanban relies on specially formatted labels in your project for it&#39;s work. Kanban LeanLabs labels use the following pattern.</p>
+<p>Kanban relies on specially formatted labels in your project for its work. Kanban LeanLabs labels use the following pattern.</p>
 
 <blockquote>
 <p>KB[stage][0][Backlog]</p>
@@ -99,9 +99,9 @@
 <p><strong>Where:</strong></p>
 
 <blockquote>
-<p>KB[stage]  - reserved prefix for columns</p>
+<p>KB[stage]  - reserved column prefix</p>
 
-<p>[0] - position columns</p>
+<p>[0] - column position</p>
 
 <p>[Backlog] - column title</p>
 </blockquote>

--- a/docs/usage/index.html
+++ b/docs/usage/index.html
@@ -90,7 +90,7 @@
 						    <section class="markdown-body">
                             <h1><a name="usage-tips" class="anchor" href="#usage-tips" rel="nofollow" aria-hidden="true"><span class="octicon octicon-link"></span></a>Usage tips</h1>
 
-<p>Here we will provide some tips and trips on kanban usage.</p>
+<p>Here we will provide some tips and tricks on kanban usage.</p>
 
 <p><a href="/docs/usage/customize-columns.html" rel="nofollow">How to customize columns</a></p>
 

--- a/enterprise/index.html
+++ b/enterprise/index.html
@@ -80,10 +80,10 @@ permalink: /enterprise
             <h4>  
             Hello, dear customer! 
             We are <a href="https://github.com/cnam" title="cnam">@cnam</a> and <a href="https://github.com/vasiliy-t" title="V">@V</a> the developers of Leanlabs.io Kanban board.
-                Today we are presenting you with our next major step - <b>Enterprise Edition</b>.
-                May be you wondering how to pay or how to get license to install kanban board EE? Enterprise is now available for free.
-                Why? Because we are developers and have no experience on establishing business, accounting and so on. So, Enterprise edition
-                is free for now, until we will know how to accept payments, it about 2 or more months, we are not in rush with this :)
+                We are proud to present our next major step - <b>Enterprise Edition</b>.
+                Maybe you are wondering how to pay or how to get a license to install kanban board EE? Enterprise is now available for free.
+                Why? Because we are developers and have no experience in establishing a business, accounting and so on. So Enterprise edition
+                is free for now, until we will know how to accept payments - about 2 or more months. We are not in rush with this :)
         </h4>
         </div>
     </section>
@@ -99,13 +99,13 @@ permalink: /enterprise
                 <div class="6u 12u$(small)">
                     <h3>Process tracking and improvement!</h3>
                     <p>
-                        Measure right things to improve your process efficiency with our lean analytics module. Track work in progress, lead time, cycle time and throughput to reduce waste and focus on what really matters.
+                        Measure the right things to improve your process efficiency with our lean analytics module. Track work in progress, lead time, cycle time and throughput to reduce waste and focus on what really matters.
                     </p>
                 </div>
                 <div class="6u 12u$(small)">
                     <h3>Powerful plugins and integrations!</h3>
                     <p>
-                        Implement your vision of perfect workflow with our plugins and services integrations. Trigger CI jobs on card movement, organize automated corporate email newsletters, integrate with chat and much more is coming!
+                        Implement your vision of a perfect workflow with our plugins and services integrations. Trigger CI jobs on card movement, organize automated corporate email newsletters, integrate with chat with much more to come!
                     </p>
                 </div>
             </div>
@@ -113,7 +113,7 @@ permalink: /enterprise
                 <div class="6u 12u$(small)">
                     <h3>Real time collaboration!</h3>
                     <p>
-                        Don`t miss anything with extended comments functionality with instant board updates. It`s like chat but for issues!
+                        Don't miss anything with extended comments functionality with instant board updates. It's like chat but for issues!
                     </p>
                 </div>
                 <div class="6u 12u$(small)">
@@ -133,7 +133,7 @@ permalink: /enterprise
                 <div class="6u 12u$(small)">
                     <h3>We are with you!</h3>
                     <p>
-                        Any questions? Get troubles with our product? With enterprise version you get extended support package.
+                        Any questions? Got troubles with our product? With enterprise version you get an extended support package.
                     </p>
                 </div>
                 <div class="6u 12u$small">

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <!-- Banner -->
 <section id="banner">
         <h2>GitLab Kanban Board</h2>
-        <p>Free OpenSource self hosted Kanban board for GitLab issues</p>
+        <p>Free, open source, self-hosted, Kanban board for GitLab issues</p>
 
         <ul class="actions">
             <li>
@@ -88,7 +88,7 @@
         <div class="row wrapper style2">
             <div class="feature 6u 12u$(small)">
                 <h3>Stay connected!</h3>
-                <p>Leanlabs.io Kanban board gives your team clear understanding of who’s working on what. With instant board updates, event notifications and card states you will never miss anything and will be able to take right decisions at the right time.</p>
+                <p>Leanlabs.io Kanban board gives your team a clear understanding of who’s working on what. With instant board updates, event notifications and card states you will never miss anything and will be able to make the right decisions at the right time.</p>
             </div>
             <div class="feature 6u 12u$(small)">
                 <img class="image" src="images/features/andon.png"
@@ -102,7 +102,7 @@
             </div>
             <div class="feature 6u 12u$(small)">
                 <h3>Stay simple!</h3>
-                <p>Manage every aspect of your projects from single place. With our easy yet powerful plugins architecture of kanban board you can trigger any action from within the board. For example you can setup our Jenkins plugin to trigger jobs on card movement.</p>
+                <p>Manage every aspect of your projects from a single place. With the easy yet powerful plugin architecture you can trigger any action from within the board. For example you can setup our Jenkins plugin to trigger jobs on card movement.</p>
             </div>
             <div class="feature 6u 12u$(small) only-medium">
                 <img class="image" src="images/features/drag-and-drop.png"
@@ -112,7 +112,7 @@
         <div class="row wrapper style2">
             <div class="fature 6u 12u$(small)">
                 <h3>Stay agile!</h3>
-                <p>Visualize your delivery process, find development activities that does not produces value to your customers and start tuning! With our customizable task boards you can easily change your delivery process to get perfect.</p>
+                <p>Visualize your delivery process, find development activities that do not produce value for your customers and start tuning! With our customizable task boards you can easily change your delivery process to achieve perfection.</p>
             </div>
             <div class="feature 6u$ 12u$(small) align-center">
                 <img class="image" src="images/features/swimlines.png"
@@ -126,7 +126,7 @@
             </div>
             <div class="feature 6u 12u$(small)">
                 <h3>Stay open!</h3>
-                <p>Leanlabs.io Kanban board is open source project and based on open source technologies and products. You can extend or fine tune it according to your business needs at any time.</p>
+                <p>Leanlabs.io Kanban board is an open source project, based on open source technologies and products. You can extend or fine tune it according to your business needs at any time.</p>
             </div>
             <div class="feature 6u 12u$(small) only-medium">
                 <img class="image" src="images/features/opensource.png"
@@ -136,7 +136,7 @@
         <div class="row wrapper style2">
             <div class="feature 6u 12u$(small)">
                 <h3>Stay tuned!</h3>
-                <p>We are releasing every week or two and your feedback is very valuable for us, so stay tuned and join us at:
+                <p>We are releasing updates every week or two and your feedback is very valuable to us, so stay tuned and join us at:
                 <ul>
                     <li><a href="https://gitter.im/leanlabsio/kanban" target="_blank">gitter chat room</a></li>
                     <li><a href="https://twitter.com/leanlabsio" target="_blank">twitter</a></li>
@@ -170,7 +170,7 @@
             <section class="feature 6u$ 12u$(small)">
                 <i class="icon big rounded fa-cloud"></i>
                 <p>
-                    Online version coming soon! For now you can try our<br/><br/>
+                    Online version coming soon! For now you can try our demo<br/><br/>
                     <a href="https://demo.kanban.leanlabs.io" target="_blank" class="button big">Try demo</a>
                 </p>
             </section>


### PR DESCRIPTION
This corrects the grammar, spelling and capitalisation of the text in the HTML documentation pages contained in `\kanban\docs` and `\kanban\enterprise`
