### PR TITLE
Nginx with https

### DIFF
--- a/docs/configuration/webserver/nginx/nginx_https.conf
+++ b/docs/configuration/webserver/nginx/nginx_https.conf
@@ -1,0 +1,70 @@
+upstream kanban_server {
+    server 127.0.0.1:9000 fail_timeout=0;
+}
+
+server {
+   server_name kanban.yourserver.com;
+
+## SSL ##
+# SSL info based on info from https://gist.github.com/plentz/6737338
+
+#  listen 443 ssl http2;
+   listen 443 ssl spdy;
+
+   ssl_prefer_server_ciphers on;
+   ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+   ssl_ciphers ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:DHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES128-SHA;
+
+   ssl_session_cache shared:SSL:50m;
+   ssl_session_timeout 5m;
+
+# You have to provide your own
+   ssl_dhparam /etc/nginx/dhparams.pem;
+
+   resolver 213.133.98.98;
+   ssl_stapling on;
+   ssl_stapling_verify on;
+
+   server_tokens off;
+   add_header X-Frame-Options SAMEORIGIN;
+   add_header X-Content-Type-Options nosniff;
+   add_header X-XSS-Protection "1; mode=block";
+
+## /SSL ##
+
+   ssl on;
+   ssl_certificate /etc/letsencrypt/live/kanban.yourserver.com/fullchain.pem;
+   ssl_certificate_key /etc/letsencrypt/live/kanban.yourserver.com/privkey.pem;
+
+   location /.well-known/acme-challenge {
+      alias /var/www/letsencrypt/.well-known/acme-challenge;
+   }
+
+# Letsencrypt configured with:
+# certbot-auto certonly -a webroot --webroot-path=/var/www/letsencrypt -d kanban.yourserver.com   
+
+   location / {
+      proxy_set_header    X-Forwarded-For       $proxy_add_x_forwarded_for;
+      proxy_set_header    Host                  $host;
+      proxy_set_header    X-Real-IP             $remote_addr;
+      proxy_set_header    X-Forwarded-Ssl       on;
+      proxy_set_header    X-Forwarded-Proto     https;
+      proxy_redirect off;
+
+      proxy_pass http://kanban_server;
+  }
+
+   location /ws {
+      proxy_set_header    X-Forwarded-For       $proxy_add_x_forwarded_for;
+      proxy_set_header    Host                  $host;
+      proxy_set_header    X-Forwarded-Ssl       on;
+      proxy_set_header    X-Forwarded-Proto     https;
+
+      proxy_set_header    Upgrade               $http_upgrade;
+      proxy_set_header    Connection            "upgrade";
+      proxy_set_header    Origin                "";
+
+      proxy_pass http://kanban_server;
+  }
+
+}


### PR DESCRIPTION
If Gitlab is on https, then Kanban should be on https too to prevent oauth-problems.